### PR TITLE
docs: Improve JoinHandle::abort cancellation checking description

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -162,7 +162,8 @@ impl<T> JoinHandle<T> {
     ///
     /// Awaiting a cancelled task might complete as usual if the task was
     /// already completed at the time it was cancelled, but most likely it
-    /// will complete with a `Err(JoinError::Cancelled)`.
+    /// will complete with an `Err(JoinError)` and can be checked that
+    /// it was cancelled via [`JoinError::is_cancelled`].
     ///
     /// ```rust
     /// use tokio::time;
@@ -190,6 +191,7 @@ impl<T> JoinHandle<T> {
     ///    }
     /// }
     /// ```
+    /// [`JoinError::is_cancelled`]: method@super::error::JoinError::is_cancelled
     pub fn abort(&self) {
         if let Some(raw) = self.raw {
             raw.remote_abort();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Previous description misleads that `JoinError` can be used as an exhaustive enum in _match_ statements.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Description was improved.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
